### PR TITLE
Second claim

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -11,7 +11,7 @@
   },
   "goerli": {
     "EcoClaim": {
-      "address": "0x06bCccd679e3e4fF5B50491383fb461F9d0D23eA",
+      "address": "0x170C2d953bBBCbc302A29415CE0ffDfA9e80976f",
       "startBlock": 7892580
     },
     "EcoID": {

--- a/networks.json
+++ b/networks.json
@@ -11,7 +11,7 @@
   },
   "goerli": {
     "EcoClaim": {
-      "address": "0x4C18EC224c8C015e0BE7eFCA745b12f36a9AEB90",
+      "address": "0x06bCccd679e3e4fF5B50491383fb461F9d0D23eA",
       "startBlock": 7892580
     },
     "EcoID": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,6 +36,7 @@ type VerifiedClaim @entity {
   recipient: Bytes! # address
   nonce: Int!
   tokenClaim: TokenClaim @derivedFrom(field: "verifiedClaim")
+  tokenRelease: TokenRelease @derivedFrom(field: "verifiedClaim")
   verifiers: [Verifier!]! @derivedFrom(field: "claim")
   nft: NFT @derivedFrom(field: "claim")
 }
@@ -61,7 +62,7 @@ type ClaimContract @entity {
     POINTS_MULTIPLIER: BigInt!
     claimingEndsAt: BigInt!
     tokenClaims: [TokenClaim!]! @derivedFrom(field: "claimContract")
-    releases: [Release!]! @derivedFrom(field: "claimContract")
+    tokenReleases: [TokenRelease!]! @derivedFrom(field: "claimContract")
     globals: Globals! @derivedFrom(field: "ecoClaim")
 }
 
@@ -76,12 +77,13 @@ type TokenClaim @entity {
     claimContract: ClaimContract!
 }
 
-type Release @entity {
+type TokenRelease @entity {
     id: String!
     recipient: Bytes!
     gasPayer: Bytes!
     amountEco: BigInt!
     amountEcox: BigInt!
     feeAmount: BigInt!
+    verifiedClaim: VerifiedClaim!
     claimContract: ClaimContract!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -85,5 +85,6 @@ type TokenRelease @entity {
     amountEcox: BigInt!
     feeAmount: BigInt!
     verifiedClaim: VerifiedClaim!
+    claimTime: BigInt!
     claimContract: ClaimContract!
 }

--- a/src/EcoClaim.ts
+++ b/src/EcoClaim.ts
@@ -1,4 +1,4 @@
-import { BigInt } from "@graphprotocol/graph-ts"
+import { BigInt, log } from "@graphprotocol/graph-ts"
 import {
   EcoClaim,
   InitializeEcoClaim,
@@ -12,7 +12,7 @@ import {
     TokenClaim,
     Globals,
     ClaimContract,
-    Release
+    TokenRelease
 } from "../generated/schema"
 
 export function handleInitializeEcoClaim(event: InitializeEcoClaim): void {
@@ -86,14 +86,17 @@ export function handleClaim(event: ClaimEvent): void {
 }
 
 export function handleReleaseVesting(event: ReleaseVesting): void {
-    const release = new Release(event.transaction.hash.toHexString());
+    const tokens = event.transaction.input.toString().split(" ")
+    const socialID = tokens[tokens.length-1].replaceAll(" ", "").replaceAll("\n", "").replaceAll("\u001b", "");
 
+    const release = new TokenRelease(event.transaction.hash.toHexString());
+    release.verifiedClaim = socialID;
     release.recipient = event.params.addr;
     release.gasPayer = event.params.gasPayer;
     release.amountEco = event.params.ecoBalance;
     release.amountEcox = event.params.vestedEcoXBalance;
     release.feeAmount = event.params.feeAmount;
     release.claimContract = event.address.toHexString();
-
+    
     release.save();
 }

--- a/src/EcoClaim.ts
+++ b/src/EcoClaim.ts
@@ -86,8 +86,11 @@ export function handleClaim(event: ClaimEvent): void {
 }
 
 export function handleReleaseVesting(event: ReleaseVesting): void {
-    const tokens = event.transaction.input.toString().split(" ")
-    const socialID = tokens[tokens.length-1].replaceAll(" ", "").replaceAll("\n", "").replaceAll("\u001b", "");
+    let index = event.transaction.input.toString().indexOf("twitter");
+    if (index < 0) {
+        index = event.transaction.input.toString().indexOf("discord");
+    }
+    const socialID = event.transaction.input.toString().substring(index);
 
     const release = new TokenRelease(event.transaction.hash.toHexString());
     release.verifiedClaim = socialID;
@@ -96,6 +99,7 @@ export function handleReleaseVesting(event: ReleaseVesting): void {
     release.amountEco = event.params.ecoBalance;
     release.amountEcox = event.params.vestedEcoXBalance;
     release.feeAmount = event.params.feeAmount;
+    release.claimTime = event.block.timestamp;
     release.claimContract = event.address.toHexString();
     
     release.save();


### PR DESCRIPTION
Completed tracking of second claim:
- Renamed `Release` entity to `TokenRelease`
- Added two-way one-to-one `TokenRelease` to `VerifiedClaim` association by parsing socialID from `ReleaseVesting` transaction input data
- added `TokenRelease` timestamp attribute (`claimTime`)